### PR TITLE
Add `working_directory` to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,12 @@ jobs:
 
 ### Inputs
 
-| Name        | Description                    | Required | Default |
-|-------------|--------------------------------|----------|---------|
-| `command`   | command to execute             | yes      |         |
-| `arguments` | arguments for command          | no       |         |
-| `target`    | file(s) or directory to target | no       |   `.`   |
+| Name                | Description                    | Required | Default |
+|---------------------|--------------------------------|----------|---------|
+| `command`           | command to execute             | yes      |         |
+| `arguments`         | arguments for command          | no       |         |
+| `target`            | file(s) or directory to target | no       |   `.`   |
+| `working_directory` | working directory for command  | no       |   `.`   |
 
 #### `command`
 


### PR DESCRIPTION
`working_directory` was added in #11 but its currently missing from the README