### PR TITLE
Update to Packer 1.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-# `0.3.0` (UNRELEASED, 2021-03)
+# `0.3.0` (UNRELEASED, 2021-08)
 
-* Update Dockerfile to point to packer version `1.7.0`
+* Update Dockerfile to point to packer version `1.7.4`
 * Change `target` default to `.` [#17](https://github.com/hashicorp/packer-github-actions/pull/17)
 * Mark `target` as not required [#17](https://github.com/hashicorp/packer-github-actions/pull/17)
 * Add support for working_directory [#11](https://github.com/operatehappy/packer-github-actions/pull/11)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # see https://hub.docker.com/r/hashicorp/packer/tags for all available tags
-FROM hashicorp/packer:light@sha256:93291f0b3041080b47b065b77309e5c1beee52c6bd691224d21d32e91ec9b562
+FROM hashicorp/packer:light@sha256:c81851c36f4194e56c813f1df9389f704b6a3fa293bbab13539966d3087e995b
 
 COPY "entrypoint.sh" "/entrypoint.sh"
 


### PR DESCRIPTION
Upgrade the packer base image reference to the latest light image
which is 1.7.4