### PR TITLE
docs: correct argument limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Other CLI commands (`console`, `inspect` and `version`) are _technically_ suppor
 
 `arguments` supports all options available for the respective `command`.
 
-The arguments must be provided as a single string. Multiple arguments should be concatenated like so: `-color=false -on-error=abort`
+The arguments can be provided as a single string or over multiple lines with the pipe operator. If provided on a single line they should be concatenated like so: `-color=false -on-error=abort`
 
 #### `target`
 


### PR DESCRIPTION
I am able to provide arguments over multiple lines e.g.

```yaml
      - name: Build
        uses: hashicorp/packer-github-actions@master
        with:
          command: build
          arguments: |
            -on-error=abort
            -var security_group_id=sg-123123121231
            -var subnet_id=subnet-123dsad4sa54dsa
          target: images/linux-amzn2/github_agent.linux.pkr.hcl
        env:
          PACKER_LOG: 1
```