### PR TITLE
Updated Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # see https://hub.docker.com/r/hashicorp/packer/tags for all available tags
-FROM hashicorp/packer:light@sha256:f795aace438ef92e738228c21d5ceb7d5dd73ceb7e0b1efab5b0e90cbc4d4dcd
+FROM hashicorp/packer:light
 
 COPY "entrypoint.sh" "/entrypoint.sh"
 


### PR DESCRIPTION
Updated source image to always pull the latest Packer "light" image.
If it's not ok by your rules, could you update the used Packer image to 1.8.0, which was released two months ago.