### PR TITLE
fix: Add Ansible on Dockerfile + Hardening alpine packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,14 @@
-# `0.3.0` (UNRELEASED, 2021-11)
+## `1.0.0` (2020-07-30)
 
-* Update Dockerfile to point to packer version `1.7.8`
-* Change `target` default to `.` [#17](https://github.com/hashicorp/packer-github-actions/pull/17)
-* Mark `target` as not required [#17](https://github.com/hashicorp/packer-github-actions/pull/17)
-* Add support for working_directory [#11](https://github.com/operatehappy/packer-github-actions/pull/11)
-
-## `0.2.0` (2020-03-25)
-
-* Adds Packer action (#1) ([d80192d](https://github.com/ksatirli/packer-github-actions/commit/d80192d)), closes [#1](https://github.com/ksatirli/packer-github-actions/issues/1)
-* adds GitHub Actions for `code-quality` and `repository-management` ([2a0399e](https://github.com/ksatirli/packer-github-actions/commit/2a0399e))
-
-## `0.1.0` (2020-03-24)
-
-* adds base files ([6f7428a](https://github.com/ksatirli/packer-github-actions/commit/6f7428a))
+* Add initial files
+* Add ansible on base image
+* Fix vulnerabilities from base image
+  + CVE-2022-32207
+  + CVE-2022-30065
+  + CVE-2022-29187
+  + CVE-2022-2097
+  + CVE-2022-34903
+  + CVE-2022-32206
+  + CVE-2022-32208
+  + CVE-2022-32205
+  + CVE-2022-2509

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,16 @@
 # see https://hub.docker.com/r/hashicorp/packer/tags for all available tags
-FROM hashicorp/packer:light@sha256:f795aace438ef92e738228c21d5ceb7d5dd73ceb7e0b1efab5b0e90cbc4d4dcd
+FROM hashicorp/packer:light
+
+RUN apk update && \
+    apk upgrade && \
+    apk add curl=7.83.1-r2 && \
+    apk add git=2.36.2-r0 && \
+    apk add openssl=1.1.1q-r0 && \
+    apk add gnupg=2.2.35-r4 && \
+    apk add go && \
+    apk add ansible
+
+RUN rm -rf /var/cache/apk/*
 
 COPY "entrypoint.sh" "/entrypoint.sh"
 

--- a/README.md
+++ b/README.md
@@ -40,13 +40,13 @@ jobs:
 
       # fix backwards incompatibilities in template
       - name: Fix Template
-        uses: hashicorp/packer-github-actions@master
+        uses: jveraduran/packer-github-actions@master
         with:
           command: fix
 
       # validate templates
       - name: Validate Template
-        uses: hashicorp/packer-github-actions@master
+        uses: jveraduran/packer-github-actions@master
         with:
           command: validate
           arguments: -syntax-only
@@ -54,7 +54,7 @@ jobs:
 
       # build artifact
       - name: Build Artifact
-        uses: hashicorp/packer-github-actions@master
+        uses: jveraduran/packer-github-actions@master
         with:
           command: build
           arguments: "-color=false -on-error=abort"
@@ -125,7 +125,7 @@ To set `PACKER_LOG=1`, simply define the environment variable in the step config
 ```yaml
   # build artifact
   - name: Build Artifact
-    uses: hashicorp/packer-github-actions@master
+    uses: jveraduran/packer-github-actions@master
     with:
       command: build
       arguments: "-color=false -on-error=abort"

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 ---
 
-name: Packer GitHub Actions
+name: Packer GitHub Actions with Ansible Provisioner
 author: Kerim Satirli <javier.iosdesign@gmail.com>
 description: Run Packer commands
 

--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 ---
 
 name: Packer GitHub Actions
-author: Kerim Satirli <kerim@operatehappy.com>
+author: Kerim Satirli <javier.iosdesign@gmail.com>
 description: Run Packer commands
 
 inputs:


### PR DESCRIPTION
## What problem is this solving?

Ansible provisioner not working, because in the base image ansible package was not included

## Types of changes

- [X] Dockerfile: Including ansible package
- [X] Dockerfile: Upgrade son package with vulnerabilities:

- CVE-2022-32207: **curl** from **7.83.1-r1** to **7.83.1-r2**
- CVE-2022-32206: **curl** from **7.83.1-r1** to **7.83.1-r2**
- CVE-2022-32208: **curl** from **7.83.1-r1** to **7.83.1-r2**
- CVE-2022-32205: **curl** from **7.83.1-r1** to **7.83.1-r2**
- CVE-2022-30065: **busybox** from **1.35.0-r13** to **1.35.0-r15**
- CVE-2022-29187: **git** from **2.36.1-r0** to **2.36.2-r0**
- CVE-2022-2097: **openssl** from **1.1.1o-r0** to **1.1.1q-r0**
- CVE-2022-34903: **gnupg** from **2.2.35-r3** to **2.2.35-r4**
 
## Additional Info

- You can review a build workin on [Build Artifact](https://github.com/jveraduran/hashicorp-packer-aws/runs/7594053214?check_suite_focus=true)

## Checklist

- [X] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)
- [] Requires change to documentation, which has been updated accordingly.
- [X] Unit test (Add or update unit test)

## Screenshots

<img width="1221" alt="Captura de Pantalla 2022-07-30 a la(s) 17 10 34" src="https://user-images.githubusercontent.com/51175225/181996277-40ebadae-b02b-43fd-abf1-0a0c7e971e5c.png">

