### PR TITLE
fix: Add Ansible on Dockerfile + Hardening alpine packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,17 @@
 # see https://hub.docker.com/r/hashicorp/packer/tags for all available tags
 FROM hashicorp/packer:light@sha256:f795aace438ef92e738228c21d5ceb7d5dd73ceb7e0b1efab5b0e90cbc4d4dcd
 
+RUN apk update && \
+    apk upgrade && \
+    apk add curl=7.83.1-r2 && \
+    apk add git=2.36.2-r0 && \
+    apk add openssl=1.1.1q-r0 && \
+    apk add gnupg=2.2.35-r4 && \
+    apk add go && \
+    apk add ansible
+
+RUN rm -rf /var/cache/apk/*
+
 COPY "entrypoint.sh" "/entrypoint.sh"
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,10 @@ FROM hashicorp/packer:light@sha256:f795aace438ef92e738228c21d5ceb7d5dd73ceb7e0b1
 
 RUN apk update && \
     apk upgrade && \
-    apk add curl=7.83.1-r2 && \
-    apk add git=2.36.2-r0 && \
+    apk add curl && \
+    apk add git=2.32.3-r0 && \
     apk add openssl=1.1.1q-r0 && \
-    apk add gnupg=2.2.35-r4 && \
+    apk add gnupg=2.2.31-r1 && \
     apk add go && \
     apk add ansible
 


### PR DESCRIPTION
## What problem is this solving?

Ansible provisioner not working, because in the base image ansible package was not included

## Types of changes

- [X] Dockerfile: Including ansible package
- [X] Dockerfile: Upgrade son package with vulnerabilities:

- CVE-2022-32207: **curl** from **7.83.1-r1** to **7.83.1-r2**
- CVE-2022-32206: **curl** from **7.83.1-r1** to **7.83.1-r2**
- CVE-2022-32208: **curl** from **7.83.1-r1** to **7.83.1-r2**
- CVE-2022-32205: **curl** from **7.83.1-r1** to **7.83.1-r2**
- CVE-2022-30065: **busybox** from **1.35.0-r13** to **1.35.0-r15**
- CVE-2022-29187: **git** from **2.36.1-r0** to **2.36.2-r0**
- CVE-2022-2097: **openssl** from **1.1.1o-r0** to **1.1.1q-r0**
- CVE-2022-34903: **gnupg** from **2.2.35-r3** to **2.2.35-r4**
 
## Additional Info

- You can review a build workin on [Build Artifact](https://github.com/jveraduran/hashicorp-packer-aws/runs/7594053214?check_suite_focus=true)

## Checklist

- [X] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)
- [] Requires change to documentation, which has been updated accordingly.
- [X] Unit test (Add or update unit test)

## Screenshots

<img width="1221" alt="Captura de Pantalla 2022-07-30 a la(s) 17 10 34" src="https://user-images.githubusercontent.com/51175225/181996277-40ebadae-b02b-43fd-abf1-0a0c7e971e5c.png">

