### PR TITLE
Adds option to copy packer output to file

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
       - [`arguments`](#arguments)
       - [`target`](#target)
       - [`working_directory`](#working_directory)
+      - [`output_file`](#output_file)
   - [Detailed logs](#detailed-logs)
   - [Notes](#notes)
   - [Author Information](#author-information)
@@ -70,12 +71,13 @@ jobs:
 
 ### Inputs
 
-| Name                | Description                    | Required | Default |
-|---------------------|--------------------------------|----------|---------|
-| `command`           | command to execute             | yes      |         |
-| `arguments`         | arguments for command          | no       |         |
-| `target`            | file(s) or directory to target | no       |   `.`   |
-| `working_directory` | working directory for command  | no       |   `.`   |
+| Name                | Description                        | Required | Default |
+|---------------------|------------------------------------|----------|---------|
+| `command`           | command to execute                 | yes      |         |
+| `arguments`         | arguments for command              | no       |         |
+| `target`            | file(s) or directory to target     | no       |   `.`   |
+| `working_directory` | working directory for command      | no       |   `.`   |
+| `output_file`       | file for output of packer command  | no       |         |
 
 #### `command`
 
@@ -114,6 +116,10 @@ The arguments must be provided as a single string. Multiple arguments should be 
 #### `working_directory`
 
 `working_directory` supports a string consisting of a directory path. This should be a relative path in your repository where you want the packer command to run.
+
+#### `output_file`
+
+`output_file` supports a string consisting of a file path. The output of the packer command will be copied here. If left blank, no extra files are created.
 
 ## Detailed logs
 

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,9 @@ inputs:
     description: file(s) or directory to target
     required: false
     default: .
+  output_file:
+    description: file to capture output logs
+    required: false
 
 outputs:
   command:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
+set -o pipefail
 
 # fail if INPUT_COMMAND is not set
 if [ -z "${INPUT_COMMAND}" ]; then
@@ -30,5 +31,9 @@ for TARGET in "${TARGETS[@]}"; do
   echo "::debug:: Processing target ${TARGET}"
 
   # shellcheck disable=SC2086
-  ${OPERATION} "${TARGET}"
+  if [ -z "${INPUT_OUTPUT_FILE}" ]; then
+    ${OPERATION} "${TARGET}"
+  else
+    ${OPERATION} "${TARGET}" | tee -a "${INPUT_OUTPUT_FILE}"
+  fi
 done


### PR DESCRIPTION
Before, there was no way to capture the output generated by the packer command, and as such, there was no way to upload the output as an artifact for later use or for logging purposes. This pull request simply adds the `output_file` option without changing any other functionality. 

This change is reflected here: https://github.com/marketplace/actions/packer-github-actions-dh_test