### PR TITLE
feat(action): allow passing arguments to docker container

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,9 @@ inputs:
     description: file(s) or directory to target
     required: false
     default: .
+  docker-args:
+    description: Pass arguments to docker container
+    required: false
 
 outputs:
   command:
@@ -26,6 +29,8 @@ outputs:
 runs:
   using: 'docker'
   image: 'Dockerfile'
+  args:
+    - ${{ inputs.docker-args }}
 
 branding:
   color: blue


### PR DESCRIPTION
# Why
Using `packer-github-action` I would like to be able to to pass arguments to my container (such as mountpoints)

# How
Follow [Github actions docs](https://docs.github.com/en/actions/creating-actions/creating-a-docker-container-action) to add and `args` option to the `run dockerfile`